### PR TITLE
Fix/serialized config bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug where `getStepStartStates` method was importing
+  `serializedIntegrationConfig` from `test/config` instead from
+  `instance.config`.
+
 ## 1.0.0 - 2022-08-30
 
 ### Added

--- a/src/getStepStartStates.ts
+++ b/src/getStepStartStates.ts
@@ -6,7 +6,6 @@ import {
 import { SerializedIntegrationConfig } from './types';
 import { Steps } from './steps/constants';
 import { deserializeIntegrationConfig } from './utils/integrationConfig';
-import { serializedIntegrationConfig } from '../test/config';
 
 function validateInvocationConfig(
   context: IntegrationExecutionContext<SerializedIntegrationConfig>,
@@ -24,7 +23,8 @@ function validateInvocationConfig(
 export default async function getStepStartStates(
   context: IntegrationExecutionContext<SerializedIntegrationConfig>,
 ): Promise<StepStartStates> {
-  const { logger } = context;
+  const { instance, logger } = context;
+  const { config: serializedIntegrationConfig } = instance;
 
   context.instance.config = deserializeIntegrationConfig(
     serializedIntegrationConfig,


### PR DESCRIPTION
This PR fixes a bug where `getStepStartStates` method was importing `serializedIntegrationConfig` from `test/config` instead from `instance.config`. This became apparent when running `yarn test` in `integration-google-firebase`.